### PR TITLE
Fix blank page when cookies are empty

### DIFF
--- a/src/common/requests.ts
+++ b/src/common/requests.ts
@@ -8,7 +8,7 @@ export const request = (url: string, method='GET', body=null): Promise<Response>
     return fetch(Config.url + url, {
         credentials: 'include',
         headers: new Headers({
-            'Authorization': 'Token '+cookies.get('user').token,
+            'Authorization': 'Token '+cookies.get('user')?.token,
             'Content-Type': 'application/json'
             
         }),


### PR DESCRIPTION
Sungem is not loading if there is no user cookies present. As such new users are not able to open sungem. Critical issue.